### PR TITLE
调整[Gradle脚本]: 防止同步项目时无意义的version更新

### DIFF
--- a/arc_dns_injector/build.gradle
+++ b/arc_dns_injector/build.gradle
@@ -11,7 +11,9 @@ jar {
         attributes("Manifest-Version": "1.0",
                 "PreMain-Class": "git.artdeell.arcdns.ArcDNSInjectorAgent")
     }
-    File versionFile = file("../app_pojav_zh/src/main/assets/components/arc_dns_injector/version")
-    versionFile.write(String.valueOf(new Date().getTime()))
+    doLast {
+        File versionFile = file("../app_pojav_zh/src/main/assets/components/arc_dns_injector/version")
+        versionFile.write(String.valueOf(new Date().getTime()))
+    }
     destinationDirectory.set(file("../app_pojav_zh/src/main/assets/components/arc_dns_injector/"))
 }

--- a/forge_installer/build.gradle
+++ b/forge_installer/build.gradle
@@ -15,8 +15,10 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    File versionFile = file("../app_pojav_zh/src/main/assets/components/forge_installer/version")
-    versionFile.write(String.valueOf(new Date().getTime()))
+    doLast {
+        File versionFile = file("../app_pojav_zh/src/main/assets/components/forge_installer/version")
+        versionFile.write(String.valueOf(new Date().getTime()))
+    }
     manifest {
         attributes("Manifest-Version": "1.0",
                 "PreMain-Class": "git.artdeell.installer_agent.Agent")

--- a/jre_lwjgl3glfw/build.gradle
+++ b/jre_lwjgl3glfw/build.gradle
@@ -11,8 +11,10 @@ jar {
     archiveBaseName = "lwjgl-glfw-classes"
     destinationDirectory.set(file("../app_pojav_zh/src/main/assets/components/lwjgl3/"))
     // Auto update the version with a timestamp so the project jar gets updated by Pojav
-    File versionFile = file("../app_pojav_zh/src/main/assets/components/lwjgl3/version")
-    versionFile.write(String.valueOf(new Date().getTime()))
+    doLast {
+        File versionFile = file("../app_pojav_zh/src/main/assets/components/lwjgl3/version")
+        versionFile.write(String.valueOf(new Date().getTime()))
+    }
     from {
         configurations.default.collect {
             println(it.getName())


### PR DESCRIPTION
修改Gradle脚本之后同步会造成version文件更新，这并没有什么意义。应该增加doLast在主动构建完成之后再更新version文件。